### PR TITLE
Update README.md with kubectl-proxy-command for dashboard

### DIFF
--- a/kind-cluster/README.md
+++ b/kind-cluster/README.md
@@ -113,7 +113,7 @@ Start the Dashboard using kubectl proxy:
 
 ```bash
 
-kubectl proxy
+kubectl proxy --port=8001 --address=0.0.0.0 --accept-hosts='.*'
 ```
 Open the Dashboard in your browser:
 


### PR DESCRIPTION
**Start the Dashboard using kubectl proxy:**
kubectl proxy --port=8001 --address=0.0.0.0 --accept-hosts='.*'