### PR TITLE
Upgrade Kind Version to v0.29.0 for x86_64 Architecture :pencil2: :memo: 

### DIFF
--- a/kind-cluster/README.md
+++ b/kind-cluster/README.md
@@ -6,7 +6,7 @@ Install KIND and kubectl using the provided script:
 
 #!/bin/bash
 
-[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
 chmod +x ./kind
 sudo mv ./kind /usr/local/bin/kind
 


### PR DESCRIPTION
This PR updates the **kind** (Kubernetes in Docker) CLI tool version from v0.27.0 to the latest stable release **v0.29.0** for x86_64 systems.

📈 Benefits:

* Includes bug fixes, performance improvements, and new features available in Kind v0.29.0.
* Ensures compatibility with newer Kubernetes versions.
* Keeps local cluster tooling up to date with the current Kind release.

📌 Notes:
* No breaking changes expected, but it's recommended to test local cluster provisioning workflows after the upgrade.