### PR TITLE
kind-cluster/install.sh: add macOS support for Kind binary download (Intel and ARM)

### DIFF
--- a/kind-cluster/install.sh
+++ b/kind-cluster/install.sh
@@ -5,6 +5,9 @@ set -o pipefail
 
 echo "🚀 Starting installation of Docker, Kind, and kubectl..."
 
+OS=$(uname -s)
+ARCH=$(uname -m)
+
 # ----------------------------
 # 1. Install Docker
 # ----------------------------
@@ -26,14 +29,26 @@ fi
 # ----------------------------
 if ! command -v kind &>/dev/null; then
   echo "📦 Installing Kind..."
-
-  ARCH=$(uname -m)
-  if [ "$ARCH" = "x86_64" ]; then
-    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
-  elif [ "$ARCH" = "aarch64" ]; then
-    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-arm64
+  if [ "$OS" = "Linux" ]; then
+    if [ "$ARCH" = "x86_64" ]; then
+      curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
+    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+      curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-arm64
+    else
+      echo "❌ Unsupported Linux architecture: $ARCH"
+      exit 1
+    fi
+  elif [ "$OS" = "Darwin" ]; then
+    if [ "$ARCH" = "x86_64" ]; then
+      curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-darwin-amd64
+    elif [ "$ARCH" = "arm64" ]; then
+      curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-darwin-arm64
+    else
+      echo "❌ Unsupported macOS architecture: $ARCH"
+      exit 1
+    fi
   else
-    echo "❌ Unsupported architecture: $ARCH"
+    echo "❌ Unsupported OS: $OS"
     exit 1
   fi
 


### PR DESCRIPTION
### What
- Update Kind installation to detect OS (Linux vs macOS) and CPU architecture.
- On macOS (Darwin), download the appropriate Kind binary:
    - Intel (x86_64): kind-darwin-amd64
    - Apple Silicon (arm64): kind-darwin-arm64
 - On Linux, retain existing logic for:
     - x86_64: kind-linux-amd64
     - arm64/aarch64: kind-linux-arm64

### Why
The previous script handled only Linux binaries. On macOS, the install failed because the Linux binary was fetched.

### Scope
Only the Kind installation section was changed. Docker and kubectl installation flows remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Installer now auto-detects OS and CPU architecture.
  - Adds native support for Linux (amd64, arm64) and macOS (Intel, Apple Silicon).
- Improvements
  - Uses platform-specific Kind binaries for more reliable installs.
  - Provides clear error messages for unsupported platforms.
  - Keeps post-install steps and success messaging consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->