### PR TITLE
Add extra port mappings for worker nodes

### DIFF
--- a/kind-cluster/kind-config.yml
+++ b/kind-cluster/kind-config.yml
@@ -7,3 +7,10 @@ nodes:
     image: kindest/node:v1.33.1
   - role: worker
     image: kindest/node:v1.33.1
+    extraPortMappings:
+    - containerPort: 80
+      hostPort: 80
+      protocol: TCP # Optional, defaults to tcp
+    - containerPort: 443
+      hostPort: 443
+      protocol: TCP # Optional, defaults to tcp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured port mappings to enable HTTP (port 80) and HTTPS (port 443) access to the development cluster.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->