### PR TITLE
Modify kind-config for cluster name and node versions

### DIFF
--- a/kind-cluster/kind-config.yml
+++ b/kind-cluster/kind-config.yml
@@ -1,9 +1,17 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: tws-cluster
+
 nodes:
-  - role: control-plane
-    image: kindest/node:v1.33.1
-  - role: worker
-    image: kindest/node:v1.33.1
-  - role: worker
-    image: kindest/node:v1.33.1
+- role: control-plane
+  image: kindest/node:v1.35.0
+  extraPortMappings:
+    - containerPort: 30080
+      hostPort: 8080
+      protocol: TCP
+
+- role: worker
+  image: kindest/node:v1.35.0
+
+- role: worker
+  image: kindest/node:v1.35.0


### PR DESCRIPTION
Updated cluster name and node images to v1.35.0 with extra port mappings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled explicit cluster naming configuration.
  * Added port mapping for external service access (internal port 30080 → external port 8080).

* **Chores**
  * Upgraded Kubernetes node images from v1.33.1 to v1.35.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->