### PR TITLE
Fix: Markdown formatting issue in Kubernetes architecture doc

### DIFF
--- a/kubernetes_architecture.md
+++ b/kubernetes_architecture.md
@@ -79,4 +79,4 @@ Think of this as the "front door" for external access to your applications, cont
 
 And there you have it! That's a simplified breakdown of Kubernetes architecture components.
 
-```
+


### PR DESCRIPTION
## Changes
- Removed extra closing code block at the end of the file
- Minor formatting improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed formatting in architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->