### PR TITLE
chore: update kind node image to v1.35.1

### DIFF
--- a/kind-cluster/README.md
+++ b/kind-cluster/README.md
@@ -12,11 +12,11 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.35.1
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.35.1
   - role: worker
-    image: kindest/node:v1.33.1
+    image: kindest/node:v1.35.1
 ```
 Create the cluster using the configuration file:
 


### PR DESCRIPTION
## Summary
Updated the KIND node image from `v1.33.1` to `v1.35.1` in the cluster configuration.

## Why this change?
- Uses a newer Kubernetes version
- Improves compatibility with latest tooling
- Avoids potential issues with outdated images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated KIND cluster documentation to use Kubernetes v1.35.1 for all cluster nodes (upgraded from v1.33.1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->