### PR TITLE
Update Kubernetes installation commands to v1.35

### DIFF
--- a/Kubeadm_Installation_Scripts_and_Documentation/README.md
+++ b/Kubeadm_Installation_Scripts_and_Documentation/README.md
@@ -111,15 +111,10 @@ This guide outlines the steps needed to set up a Kubernetes cluster using `kubea
 
 5. **Install Kubernetes Components**:
     ```bash
-    sudo apt-get update
-    sudo apt-get install -y apt-transport-https ca-certificates curl gpg
-
-    curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-
-    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
-
-    sudo apt-get update
-    sudo apt-get install -y kubelet kubeadm kubectl
+    sudo apt-get update sudo apt-get install -y apt-transport-https ca-certificates curl gpg sudo mkdir -p /etc/apt/keyrings curl -fsSL
+    https://pkgs.k8s.io/core:/stable:/v1.35/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-
+    keyring.gpg]
+    https://pkgs.k8s.io/core:/stable:/v1.35/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list sudo apt-get update sudo apt-get install -y kubelet kubeadm kubectl
     sudo apt-mark hold kubelet kubeadm kubectl
     ```
 


### PR DESCRIPTION
made changes to use v1.35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes component installation instructions to use v1.35 (previously v1.29)
  * Simplified the apt keyring and source configuration steps in the installation guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->