### PR TITLE
Activate docker group changes with newgrp command

### DIFF
--- a/kind-cluster/install.sh
+++ b/kind-cluster/install.sh
@@ -15,6 +15,7 @@ if ! command -v docker &>/dev/null; then
 
   echo "👤 Adding current user to docker group..."
   sudo usermod -aG docker "$USER"
+  newgrp docker
 
   echo "✅ Docker installed and user added to docker group."
 else


### PR DESCRIPTION
Add newgrp command to activate docker group changes immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker group access now takes effect immediately during installation, so Docker commands can be used in the current shell session without restarting or logging out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->